### PR TITLE
fix Ambiguous class resolution for symfony contracts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "mtdowling/cron-expression": "^1.2",
         "sylius/sylius": "^1.5",
         "symfony/lock": "^3.4|^4.3",
-        "symfony/contracts": "^1.1|^2.0",
+        "symfony/service-contracts": "^1.1|^2.0",
         "symfony/framework-bundle": "^4.4",
         "symfony/process": "^4.4"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?   | no
| Fixed issue | 

Updated requirement symfony/contracts to symfony/service-contracts installation does not generate ambiguous classes with an optimized composer autoloader.