### PR TITLE
Fix issue 30 : Save error code non existent command

### DIFF
--- a/src/Command/SynoliaSchedulerRunCommand.php
+++ b/src/Command/SynoliaSchedulerRunCommand.php
@@ -105,6 +105,9 @@ final class SynoliaSchedulerRunCommand extends Command
             $command = $application->find($scheduledCommand->getCommand());
         } catch (\InvalidArgumentException $e) {
             $scheduledCommand->setLastReturnCode(-1);
+            //persist last return code
+            $this->entityManager->merge($scheduledCommand);
+            $this->entityManager->flush();
             $io->error('Cannot find ' . $scheduledCommand->getCommand());
 
             return;

--- a/tests/PHPUnit/Command/SynoliaSchedulerRunCommandTest.php
+++ b/tests/PHPUnit/Command/SynoliaSchedulerRunCommandTest.php
@@ -8,6 +8,8 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Synolia\SyliusSchedulerCommandPlugin\Entity\ScheduledCommand;
+use Synolia\SyliusSchedulerCommandPlugin\Entity\ScheduledCommandInterface;
+use Synolia\SyliusSchedulerCommandPlugin\Repository\ScheduledCommandRepositoryInterface;
 use Tests\Synolia\SyliusSchedulerCommandPlugin\PHPUnit\WithDatabaseTrait;
 
 final class SynoliaSchedulerRunCommandTest extends KernelTestCase
@@ -76,6 +78,52 @@ final class SynoliaSchedulerRunCommandTest extends KernelTestCase
         self::assertStringContainsString('Immediately execution asked for : about', $commandTester->getDisplay());
         self::assertStringContainsString('Execute Command "about" - last execution : never', $commandTester->getDisplay());
         self::assertStringNotContainsString('Nothing to do', $commandTester->getDisplay());
+    }
+
+    /**
+     * @group toto
+     */
+    public function testExecuteNonExistentCommand(): void
+    {
+        $invalidCommandName = 'non:existent';
+
+        //remove last test
+        /** @var EntityManagerInterface $em */
+        $em = static::$container->get(EntityManagerInterface::class);
+        /** @var ScheduledCommandRepositoryInterface $repository */
+        $repository = $em->getRepository(ScheduledCommand::class);
+
+        $lastScheduledCommand = $repository->findOneBy(['command' => $invalidCommandName]);
+        if($lastScheduledCommand !== null) {
+            $repository->remove($lastScheduledCommand);
+        }
+
+
+        //generate command
+        /** @var ScheduledCommand $scheduledCommand */
+        $scheduledCommand = (new Factory(ScheduledCommand::class))->createNew();
+        $scheduledCommand
+            ->setCronExpression('* * * * *')
+            ->setCommand('non:existent');
+
+        $this->save($scheduledCommand);
+
+        //run command
+        $application = new Application(static::$kernel);
+
+        $command = $application->find(self::$commandName);
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        //assertion
+        self::assertStringContainsString('Cannot find non:existent', $commandTester->getDisplay());
+
+        $persistedScheduledCommand = $repository->findOneBy(['command' => $invalidCommandName]);
+
+        self::assertEquals(
+            -1,
+            $persistedScheduledCommand->getLastReturnCode()
+        );
     }
 
     private function generateAboutScheduleCommand(string $cron): ScheduledCommand


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed issue   | #30 
| License       | MIT

Save last error code for non existent function when is running at  last command
