### PR TITLE
Replace deprecated EngineInterface with Environment

### DIFF
--- a/src/Grid/FieldType/ScheduledCommandExecutionTimeType.php
+++ b/src/Grid/FieldType/ScheduledCommandExecutionTimeType.php
@@ -8,7 +8,7 @@ use Sylius\Component\Grid\Definition\Field;
 use Sylius\Component\Grid\FieldTypes\FieldTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Templating\EngineInterface;
+use Twig\Environment;
 
 class ScheduledCommandExecutionTimeType implements FieldTypeInterface
 {
@@ -19,10 +19,10 @@ class ScheduledCommandExecutionTimeType implements FieldTypeInterface
     /** @var \Symfony\Component\Routing\Generator\UrlGeneratorInterface */
     private $urlGenerator;
 
-    /** @var \Symfony\Component\Templating\EngineInterface */
+    /** @var Environment */
     private $engine;
 
-    public function __construct(UrlGeneratorInterface $urlGenerator, EngineInterface $engine)
+    public function __construct(UrlGeneratorInterface $urlGenerator, Environment $engine)
     {
         $this->urlGenerator = $urlGenerator;
         $this->engine = $engine;

--- a/src/Grid/FieldType/ScheduledCommandHumanReadableExpressionType.php
+++ b/src/Grid/FieldType/ScheduledCommandHumanReadableExpressionType.php
@@ -8,14 +8,14 @@ use Sivaschenko\Utility\Cron\ExpressionFactory;
 use Sylius\Component\Grid\Definition\Field;
 use Sylius\Component\Grid\FieldTypes\FieldTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Templating\EngineInterface;
+use Twig\Environment;
 
 final class ScheduledCommandHumanReadableExpressionType implements FieldTypeInterface
 {
-    /** @var \Symfony\Component\Templating\EngineInterface */
+    /** @var Environment */
     private $engine;
 
-    public function __construct(EngineInterface $engine)
+    public function __construct(Environment $engine)
     {
         $this->engine = $engine;
     }

--- a/src/Grid/FieldType/ScheduledCommandUrlType.php
+++ b/src/Grid/FieldType/ScheduledCommandUrlType.php
@@ -8,14 +8,14 @@ use Sylius\Component\Grid\Definition\Field;
 use Sylius\Component\Grid\FieldTypes\FieldTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Templating\EngineInterface;
+use Twig\Environment;
 
 final class ScheduledCommandUrlType implements FieldTypeInterface
 {
     /** @var \Symfony\Component\Routing\Generator\UrlGeneratorInterface */
     private $urlGenerator;
 
-    /** @var \Symfony\Component\Templating\EngineInterface */
+    /** @var Environment */
     private $engine;
 
     /** @var string */
@@ -23,7 +23,7 @@ final class ScheduledCommandUrlType implements FieldTypeInterface
 
     public function __construct(
         UrlGeneratorInterface $urlGenerator,
-        EngineInterface $engine,
+        Environment $engine,
         string $logsDir
     ) {
         $this->urlGenerator = $urlGenerator;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Fixed issue   | 
| License       | MIT

Hi! This PR will replace deprecated Engine Templating with Twig Environment to allow compatibility with Sylius 1.9 and Symfony 5.
