### PR TITLE
fix project dir for console execution

### DIFF
--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -5,6 +5,7 @@ services:
         public: false
         bind:
             $logsDir: '%kernel.logs_dir%'
+            $projectDir: '%kernel.project_dir%'
 
     Synolia\SyliusSchedulerCommandPlugin\:
         resource: '../../*'

--- a/src/Service/ExecuteScheduleCommand.php
+++ b/src/Service/ExecuteScheduleCommand.php
@@ -25,16 +25,21 @@ class ExecuteScheduleCommand
     /** @var string */
     private $logsDir;
 
+    /** @var string */
+    private $projectDir;
+
     public function __construct(
         ScheduledCommandRepository $scheduledCommandRepository,
         EntityManagerInterface $entityManager,
         KernelInterface $kernel,
-        string $logsDir
+        string $logsDir,
+        string $projectDir
     ) {
         $this->scheduledCommandRepository = $scheduledCommandRepository;
         $this->entityManager = $entityManager;
         $this->kernel = $kernel;
         $this->logsDir = $logsDir;
+        $this->projectDir = $projectDir;
     }
 
     public function executeImmediate(string $commandId): bool
@@ -91,7 +96,8 @@ class ExecuteScheduleCommand
     private function getCommandLine(ScheduledCommandInterface $scheduledCommand): string
     {
         $commandLine = sprintf(
-            'bin/console %s %s',
+            '%s/bin/console %s %s',
+            $this->projectDir,
             $scheduledCommand->getCommand(),
             $scheduledCommand->getArguments() ?? ''
         );
@@ -99,7 +105,8 @@ class ExecuteScheduleCommand
         $logOutput = $this->getLogOutput($scheduledCommand);
         if (null !== $logOutput) {
             $commandLine = sprintf(
-                'bin/console %s %s >> %s 2>> %s',
+                '%s/bin/console %s %s >> %s 2>> %s',
+                $this->projectDir,
                 $scheduledCommand->getCommand(),
                 $scheduledCommand->getArguments() ?? '',
                 $logOutput,

--- a/tests/PHPUnit/Command/SynoliaSchedulerRunCommandTest.php
+++ b/tests/PHPUnit/Command/SynoliaSchedulerRunCommandTest.php
@@ -80,9 +80,6 @@ final class SynoliaSchedulerRunCommandTest extends KernelTestCase
         self::assertStringNotContainsString('Nothing to do', $commandTester->getDisplay());
     }
 
-    /**
-     * @group toto
-     */
     public function testExecuteNonExistentCommand(): void
     {
         $invalidCommandName = 'non:existent';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed issue   | 
| License       | MIT

When Command is run like this ;
```
php __directory__/bin/console synolia:scheduler-run
```
Sub Command throw error :
> sh: 1: bin/console: not found

This PR fix it 🎉 