### PR TITLE
[Readme] change suggested package for parse cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@
 
 4. (optional) Showing humanized cron expression
 
-        composer require dragonmantank/cron-expression
+        composer require lorisleiva/cron-translator
 
 5. Till `symfony/recipes-contrib` is updated for the v3, you must add `sylius_scheduler_command.yaml` from `install/Application/config/{packages,routes}` to your project by respecting the same folder architecture.
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed issue   | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Hi :wave: 

Following readme,  I tried to install `dragonmantank/cron-expression` to show humanized cron expression. 

However, this plugin already require it, and no humanized cron expression is displayed. 

Regarding `composer.json`, it came out that it should be `lorisleiva/cron-translator`. Let's update that readme :rocket: 

In a second time, we should check if `dragonmantank/cron-expression` is really mandatory
