### PR TITLE
plan commands even if the scheduler is already running otherwise sche…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,10 +79,6 @@ jobs:
               run: (test -f grumphp.yml && vendor/bin/grumphp run) || echo Grumphp ruleset file does not exist, skipping step
               if: always() && steps.end-of-setup.outcome == 'success'
 
-            - name: PHPSpec - Run
-              run: vendor/bin/phpspec run
-              if: always() && steps.end-of-setup.outcome == 'success'
-
             - name: Checks security issues - Run
               run: symfony security:check
               if: always() && steps.end-of-setup.outcome == 'success'

--- a/spec/Command/SynoliaSchedulerRunCommandSpec.php
+++ b/spec/Command/SynoliaSchedulerRunCommandSpec.php
@@ -6,6 +6,7 @@ namespace spec\Synolia\SyliusSchedulerCommandPlugin\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
 use PhpSpec\ObjectBehavior;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Synolia\SyliusSchedulerCommandPlugin\Command\SynoliaSchedulerRunCommand;
 use Synolia\SyliusSchedulerCommandPlugin\Planner\ScheduledCommandPlannerInterface;
@@ -22,7 +23,8 @@ class SynoliaSchedulerRunCommandSpec extends ObjectBehavior
         CommandRepositoryInterface $commandRepository,
         ScheduledCommandRepositoryInterface $scheduledCommandRepository,
         ScheduledCommandPlannerInterface $scheduledCommandPlanner,
-        IsDueVoterInterface $isDueVoter
+        IsDueVoterInterface $isDueVoter,
+        LoggerInterface $logger
     ) {
         $this->beConstructedWith(
             $scheduledCommandManager,
@@ -30,7 +32,8 @@ class SynoliaSchedulerRunCommandSpec extends ObjectBehavior
             $commandRepository,
             $scheduledCommandRepository,
             $scheduledCommandPlanner,
-            $isDueVoter
+            $isDueVoter,
+            $logger
         );
     }
 

--- a/src/Command/SynoliaSchedulerRunCommand.php
+++ b/src/Command/SynoliaSchedulerRunCommand.php
@@ -6,6 +6,7 @@ namespace Synolia\SyliusSchedulerCommandPlugin\Command;
 
 use Doctrine\DBAL\Exception\ConnectionLost;
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\LockableTrait;
@@ -46,13 +47,16 @@ final class SynoliaSchedulerRunCommand extends Command
     /** @var IsDueVoterInterface */
     private $isDueVoter;
 
+    private LoggerInterface $logger;
+
     public function __construct(
         EntityManagerInterface $scheduledCommandManager,
         ScheduleCommandRunnerInterface $scheduleCommandRunner,
         CommandRepositoryInterface $commandRepository,
         ScheduledCommandRepositoryInterface $scheduledCommandRepository,
         ScheduledCommandPlannerInterface $scheduledCommandPlanner,
-        IsDueVoterInterface $isDueVoter
+        IsDueVoterInterface $isDueVoter,
+        LoggerInterface $logger
     ) {
         parent::__construct(static::$defaultName);
 
@@ -62,6 +66,7 @@ final class SynoliaSchedulerRunCommand extends Command
         $this->scheduledCommandRepository = $scheduledCommandRepository;
         $this->scheduledCommandPlanner = $scheduledCommandPlanner;
         $this->isDueVoter = $isDueVoter;
+        $this->logger = $logger;
     }
 
     protected function configure(): void
@@ -72,12 +77,6 @@ final class SynoliaSchedulerRunCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        if (!$this->lock()) {
-            $output->writeln('The command is already running in another process.');
-
-            return 0;
-        }
-
         $io = new SymfonyStyle($input, $output);
 
         $scheduledCommandId = $input->getOption('id');
@@ -103,6 +102,13 @@ final class SynoliaSchedulerRunCommand extends Command
             if ($this->shouldExecuteCommand($command, $io)) {
                 $this->scheduledCommandPlanner->plan($command);
             }
+        }
+
+        if (!$this->lock()) {
+            $output->writeln('The command is already running in another process.');
+            $this->logger->info('Scheduler is already running.');
+
+            return 0;
         }
 
         /** @var ScheduledCommandInterface[] $scheduledCommands */

--- a/src/Planner/ScheduledCommandPlanner.php
+++ b/src/Planner/ScheduledCommandPlanner.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Synolia\SyliusSchedulerCommandPlugin\Planner;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 use Synolia\SyliusSchedulerCommandPlugin\Entity\CommandInterface;
 use Synolia\SyliusSchedulerCommandPlugin\Entity\ScheduledCommandInterface;
@@ -17,12 +18,16 @@ class ScheduledCommandPlanner implements ScheduledCommandPlannerInterface
     /** @var \Doctrine\ORM\EntityManagerInterface */
     private $entityManager;
 
+    private LoggerInterface $logger;
+
     public function __construct(
         FactoryInterface $scheduledCommandFactory,
-        EntityManagerInterface $entityManager
+        EntityManagerInterface $entityManager,
+        LoggerInterface $logger
     ) {
         $this->scheduledCommandFactory = $scheduledCommandFactory;
         $this->entityManager = $entityManager;
+        $this->logger = $logger;
     }
 
     public function plan(CommandInterface $command): ScheduledCommandInterface
@@ -50,6 +55,8 @@ class ScheduledCommandPlanner implements ScheduledCommandPlannerInterface
 
         $this->entityManager->persist($scheduledCommand);
         $this->entityManager->flush();
+
+        $this->logger->info('Command has been planned for execution.', ['command_name' => $command->getName()]);
 
         return $scheduledCommand;
     }

--- a/tests/Behat/Context/Cli/CliContext.php
+++ b/tests/Behat/Context/Cli/CliContext.php
@@ -7,6 +7,7 @@ namespace Tests\Synolia\SyliusSchedulerCommandPlugin\Behat\Context\Cli;
 use Behat\Behat\Context\Context;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Assert;
+use Psr\Log\LoggerInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -60,6 +61,8 @@ class CliContext implements Context
     /** @var IsDueVoterInterface */
     private $isDueVoter;
 
+    private LoggerInterface $logger;
+
     public function __construct(
         KernelInterface $kernel,
         SharedStorageInterface $sharedStorage,
@@ -68,7 +71,8 @@ class CliContext implements Context
         CommandRepositoryInterface $commandRepository,
         ScheduledCommandRepositoryInterface $scheduledCommandRepository,
         ScheduledCommandPlannerInterface $scheduledCommandPlanner,
-        IsDueVoterInterface $isDueVoter
+        IsDueVoterInterface $isDueVoter,
+        LoggerInterface $logger
     ) {
         $this->kernel = $kernel;
         $this->sharedStorage = $sharedStorage;
@@ -78,6 +82,7 @@ class CliContext implements Context
         $this->scheduledCommandRepository = $scheduledCommandRepository;
         $this->scheduledCommandPlanner = $scheduledCommandPlanner;
         $this->isDueVoter = $isDueVoter;
+        $this->logger = $logger;
     }
 
     /**
@@ -108,7 +113,8 @@ class CliContext implements Context
                 $this->commandRepository,
                 $this->scheduledCommandRepository,
                 $this->scheduledCommandPlanner,
-                $this->isDueVoter
+                $this->isDueVoter,
+                $this->logger
             )
         );
         $this->command = $this->application->find('synolia:scheduler-run');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| License       | MIT

Commands where not planned if the scheduler was already running.
This allows the synolia:scheduler-run command to still plan scheduled commands but will immediately exit after that if it is already running in another process.
