### PR TITLE
Allow changing logs dir parameter with env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,10 @@ install-plugin:
 	cp -r install/Application tests
 
 install-sylius:
-	${CONSOLE} sylius:install -n -s default
+	${CONSOLE} doctrine:database:create -n
+	${CONSOLE} doctrine:migrations:generate -n
+	${CONSOLE} messenger:setup-transports -n
+	${CONSOLE} sylius:fixtures:load default -n
 	${YARN} install
 	${YARN} build
 	${CONSOLE} cache:clear

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ install-plugin:
 
 install-sylius:
 	${CONSOLE} doctrine:database:create -n
-	${CONSOLE} doctrine:migrations:generate -n
+	${CONSOLE} doctrine:migrations:migrate -n
 	${CONSOLE} messenger:setup-transports -n
 	${CONSOLE} sylius:fixtures:load default -n
 	${YARN} install

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -1,6 +1,7 @@
 parameters:
     env(SYNOLIA_SCHEDULER_PLUGIN_PING_INTERVAL): 300
     env(SYNOLIA_SCHEDULER_PLUGIN_KEEP_ALIVE): true
+    env(SYNOLIA_SCHEDULER_PLUGIN_LOGS_DIR): '%kernel.logs_dir%'
 
 services:
     _defaults:
@@ -8,7 +9,7 @@ services:
         autoconfigure: true
         public: false
         bind:
-            $logsDir: '%kernel.logs_dir%'
+            $logsDir: '%env(string:SYNOLIA_SCHEDULER_PLUGIN_LOGS_DIR)%'
             $projectDir: '%kernel.project_dir%'
 
     Synolia\SyliusSchedulerCommandPlugin\:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Fixed issue   | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Because of the architecture of one of my projects, I can't save logs in the default logs dir. I needed a way to overwrite the logs dir parameter. :) 
