### PR TITLE
fix: `timeout` fields must be positive numbers (or zero)

### DIFF
--- a/src/Form/CommandType.php
+++ b/src/Form/CommandType.php
@@ -9,6 +9,7 @@ use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints;
 use Synolia\SyliusSchedulerCommandPlugin\Entity\CommandInterface;
 
 final class CommandType extends AbstractType
@@ -31,9 +32,21 @@ final class CommandType extends AbstractType
             ])
             ->add('timeout', IntegerType::class, [
                 'required' => false,
+                'constraints' => [
+                    new Constraints\PositiveOrZero(),
+                ],
+                'attr' => [
+                    'min' => 0,
+                ],
             ])
             ->add('idle_timeout', IntegerType::class, [
                 'required' => false,
+                'constraints' => [
+                    new Constraints\PositiveOrZero(),
+                ],
+                'attr' => [
+                    'min' => 0,
+                ],
             ])
             ->add('executeImmediately')
             ->add('enabled')

--- a/src/Form/ScheduledCommandType.php
+++ b/src/Form/ScheduledCommandType.php
@@ -9,6 +9,7 @@ use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints;
 use Synolia\SyliusSchedulerCommandPlugin\Entity\ScheduledCommandInterface;
 
 final class ScheduledCommandType extends AbstractType
@@ -26,9 +27,21 @@ final class ScheduledCommandType extends AbstractType
             ->add('arguments')
             ->add('timeout', IntegerType::class, [
                 'required' => false,
+                'constraints' => [
+                    new Constraints\PositiveOrZero(),
+                ],
+                'attr' => [
+                    'min' => 0,
+                ],
             ])
             ->add('idle_timeout', IntegerType::class, [
                 'required' => false,
+                'constraints' => [
+                    new Constraints\PositiveOrZero(),
+                ],
+                'attr' => [
+                    'min' => 0,
+                ],
             ])
             ->add('logFile')
         ;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed issue   | #79 
| License       | MIT
