### PR TITLE
plan command once

### DIFF
--- a/tests/PHPUnit/AbstractIsDueTest.php
+++ b/tests/PHPUnit/AbstractIsDueTest.php
@@ -17,11 +17,15 @@ abstract class AbstractIsDueTest extends KernelTestCase
     /** @var EntityManagerInterface */
     protected $entityManager;
 
+    public static function setUpBeforeClass(): void
+    {
+        $kernel = self::bootKernel();
+        self::initDatabase($kernel);
+    }
+
     public function setUp(): void
     {
         parent::setUp();
-        $kernel = self::bootKernel();
-        self::initDatabase($kernel);
 
         $this->entityManager = static::getContainer()->get(EntityManagerInterface::class);
         $this->entityManager->beginTransaction();

--- a/tests/PHPUnit/Command/PurgeScheduledCommandCommandTest.php
+++ b/tests/PHPUnit/Command/PurgeScheduledCommandCommandTest.php
@@ -25,10 +25,15 @@ final class PurgeScheduledCommandCommandTest extends KernelTestCase
 
     private ReflectionClass $reflectionClass;
 
+    public static function setUpBeforeClass(): void
+    {
+        $kernel = self::bootKernel();
+        self::initDatabase($kernel);
+    }
+
     public function setUp(): void
     {
-        $kernel = static::bootKernel();
-        self::initDatabase($kernel);
+        parent::setUp();
 
         $this->entityManager = static::getContainer()->get(EntityManagerInterface::class);
         $this->entityManager->beginTransaction();

--- a/tests/PHPUnit/Command/SynoliaSchedulerRunCommandTest.php
+++ b/tests/PHPUnit/Command/SynoliaSchedulerRunCommandTest.php
@@ -23,10 +23,15 @@ final class SynoliaSchedulerRunCommandTest extends KernelTestCase
 
     private ?EntityManagerInterface $entityManager = null;
 
+    public static function setUpBeforeClass(): void
+    {
+        $kernel = self::bootKernel();
+        self::initDatabase($kernel);
+    }
+
     public function setUp(): void
     {
-        $kernel = static::bootKernel();
-        self::initDatabase($kernel);
+        parent::setUp();
 
         $this->entityManager = static::getContainer()->get(EntityManagerInterface::class);
         $this->entityManager->beginTransaction();

--- a/tests/PHPUnit/Planner/ScheduledCommandPlannerTest.php
+++ b/tests/PHPUnit/Planner/ScheduledCommandPlannerTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Synolia\SyliusSchedulerCommandPlugin\PHPUnit\Planner;
+
+use function Amp\Promise\first;
+use Doctrine\ORM\EntityManagerInterface;
+use Sylius\Component\Resource\Factory\Factory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Synolia\SyliusSchedulerCommandPlugin\Entity\Command;
+use Synolia\SyliusSchedulerCommandPlugin\Entity\ScheduledCommandInterface;
+use Synolia\SyliusSchedulerCommandPlugin\Enum\ScheduledCommandStateEnum;
+use Synolia\SyliusSchedulerCommandPlugin\Planner\ScheduledCommandPlannerInterface;
+use Tests\Synolia\SyliusSchedulerCommandPlugin\PHPUnit\WithDatabaseTrait;
+
+class ScheduledCommandPlannerTest extends KernelTestCase
+{
+    use WithDatabaseTrait;
+
+    private EntityManagerInterface $entityManager;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $kernel = self::bootKernel();
+        self::initDatabase($kernel);
+        $this->entityManager = static::getContainer()->get(EntityManagerInterface::class);
+    }
+
+    public function testPlanACommand(): void
+    {
+        $command = $this->getCommand();
+
+        /** @var ScheduledCommandPlannerInterface $planner */
+        $planner = static::getContainer()->get(ScheduledCommandPlannerInterface::class);
+        $scheduledCommand = $planner->plan($command);
+
+        $count = $this->entityManager->getRepository(ScheduledCommandInterface::class)->count([]);
+        $this->assertEquals(1, $count);
+
+        $scheduledCommandsOnDatabase = $this->entityManager->getRepository(ScheduledCommandInterface::class)->findBy([
+            'command' => 'about',
+            'state' => ScheduledCommandStateEnum::WAITING,
+        ]);
+        $this->assertCount(1, $scheduledCommandsOnDatabase);
+        /** @var ScheduledCommandInterface $scheduledCommandOnDatabase */
+        $scheduledCommandOnDatabase = $scheduledCommandsOnDatabase[0];
+        $this->assertSame($scheduledCommand->getCommand(), $scheduledCommandOnDatabase->getCommand());
+    }
+
+    public function testPlanACommandTwice(): void
+    {
+        $command = $this->getCommand();
+
+        /** @var ScheduledCommandPlannerInterface $planner */
+        $planner = static::getContainer()->get(ScheduledCommandPlannerInterface::class);
+        // first plan
+        $planner->plan($command);
+        // seconde plan
+        $planner->plan($command);
+
+        $scheduledCommandsOnDatabase = $this->entityManager->getRepository(ScheduledCommandInterface::class)->findBy([
+            'command' => 'about',
+            'state' => ScheduledCommandStateEnum::WAITING,
+        ]);
+
+        // Command must by scheduled only once time
+        $this->assertCount(1, $scheduledCommandsOnDatabase);
+    }
+
+    private function getCommand(): Command
+    {
+        /** @var Command $command */
+        $command = (new Factory(Command::class))->createNew();
+        $command
+            ->setName('Plan Command')
+            ->setCommand('about')
+        ;
+
+        $this->entityManager->persist($command);
+        $this->entityManager->flush();
+
+        return $command;
+    }
+}

--- a/tests/PHPUnit/Service/ExecuteScheduleCommandTest.php
+++ b/tests/PHPUnit/Service/ExecuteScheduleCommandTest.php
@@ -20,11 +20,15 @@ class ExecuteScheduleCommandTest extends WebTestCase
 
     private ?EntityManagerInterface $entityManager = null;
 
+    public static function setUpBeforeClass(): void
+    {
+        $kernel = self::bootKernel();
+        self::initDatabase($kernel);
+    }
+
     public function setUp(): void
     {
         parent::setUp();
-        $kernel = self::bootKernel();
-        self::initDatabase($kernel);
 
         $this->scheduleCommandRunner = static::getContainer()->get(ScheduleCommandRunnerInterface::class);
         $this->entityManager = static::getContainer()->get(EntityManagerInterface::class);

--- a/tests/PHPUnit/WithDatabaseTrait.php
+++ b/tests/PHPUnit/WithDatabaseTrait.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Tests\Synolia\SyliusSchedulerCommandPlugin\PHPUnit;
 
 use Doctrine\ORM\Tools\SchemaTool;
+use Sylius\Bundle\FixturesBundle\Loader\SuiteLoaderInterface;
+use Sylius\Bundle\FixturesBundle\Suite\SuiteRegistryInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 trait WithDatabaseTrait
@@ -24,6 +26,12 @@ trait WithDatabaseTrait
         $schemaTool = new SchemaTool($entityManager);
         $schemaTool->updateSchema($metadatas);
 
-        // If you are using the Doctrine Fixtures Bundle you could load these here
+        /** @var SuiteRegistryInterface $suiteRegistry */
+        $suiteRegistry = $kernel->getContainer()->get(SuiteRegistryInterface::class);
+        $suite = $suiteRegistry->getSuite('default');
+
+        /** @var SuiteLoaderInterface $suiteLoader */
+        $suiteLoader = $kernel->getContainer()->get(SuiteLoaderInterface::class);
+        $suiteLoader->load($suite);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Fixed issue   | 
| License       | MIT

If a command takes a long time to execute, the scheduler can stack the same pending command several times.
A command should only be queued once.