### PR TITLE
Define a different timezone for scheduled tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ Execute scheduled commands.
 
 **Run a specific scheduled command :** php bin/console synolia:scheduler-run --id=5
 
+Is it possible to choose the timezone of the command execution by setting the `SYNOLIA_SCHEDULER_PLUGIN_TIMEZONE` environment variable, example: 
+
+```
+SYNOLIA_SCHEDULER_PLUGIN_TIMEZONE=Europe/Paris
+```
+
 ### synolia:scheduler:purge-history
 
 Purge scheduled command history greater than {X} days old.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,7 +7,7 @@
 
 Also, for old existing schedules in your database, please remove the log file extension in column `logFilePrefix`.
 
-## from 3.6 to 3.7
+## from 3.8 to 3.9
 
 * The constructors of `Synolia\SyliusSchedulerCommandPlugin\Checker\EveryMinuteIsDueChecker` and `Synolia\SyliusSchedulerCommandPlugin\Checker\SoftLimitThresholdIsDueChecker` has been modified, a new argument has been added :
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,3 +6,14 @@
 * `logFile` field must be renamed to `logFilePrefix` and must not end with the file extension
 
 Also, for old existing schedules in your database, please remove the log file extension in column `logFilePrefix`.
+
+## from 3.6 to 3.7
+
+* The constructors of `Synolia\SyliusSchedulerCommandPlugin\Checker\EveryMinuteIsDueChecker` and `Synolia\SyliusSchedulerCommandPlugin\Checker\SoftLimitThresholdIsDueChecker` has been modified, a new argument has been added :
+
+   ```php
+    public function __construct(
+        // ...
+        private ?DateTimeProviderInterface $dateTimeProvider = null,
+    )
+    ```

--- a/src/Checker/EveryMinuteIsDueChecker.php
+++ b/src/Checker/EveryMinuteIsDueChecker.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Synolia\SyliusSchedulerCommandPlugin\Checker;
 
 use Cron\CronExpression;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 use Sylius\Calendar\Provider\DateTimeProviderInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 use Synolia\SyliusSchedulerCommandPlugin\Components\Exceptions\Checker\IsNotDueException;
 use Synolia\SyliusSchedulerCommandPlugin\Entity\CommandInterface;
 
@@ -19,9 +19,9 @@ class EveryMinuteIsDueChecker implements IsDueCheckerInterface
     private const PRIORITY = 0;
 
     public function __construct(
-        private ?DateTimeProviderInterface $dateTimeProvider = null,
+        private readonly ?DateTimeProviderInterface $dateTimeProvider = null,
     ) {
-        if (null === $dateTimeProvider) {
+        if (!$dateTimeProvider instanceof DateTimeProviderInterface) {
             trigger_deprecation(
                 'synolia/sylius-scheduler-command-plugin',
                 '3.9',
@@ -42,7 +42,7 @@ class EveryMinuteIsDueChecker implements IsDueCheckerInterface
      */
     public function isDue(CommandInterface $command, ?\DateTimeInterface $dateTime = null): bool
     {
-        if (null === $dateTime) {
+        if (!$dateTime instanceof \DateTimeInterface) {
             $dateTime = $this->dateTimeProvider?->now() ?? new \DateTime();
         }
 

--- a/src/Checker/SoftLimitThresholdIsDueChecker.php
+++ b/src/Checker/SoftLimitThresholdIsDueChecker.php
@@ -6,6 +6,7 @@ namespace Synolia\SyliusSchedulerCommandPlugin\Checker;
 
 use Cron\CronExpression;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Sylius\Calendar\Provider\DateTimeProviderInterface;
 use Synolia\SyliusSchedulerCommandPlugin\Components\Exceptions\Checker\IsNotDueException;
 use Synolia\SyliusSchedulerCommandPlugin\Entity\CommandInterface;
 use Synolia\SyliusSchedulerCommandPlugin\Repository\ScheduledCommandRepositoryInterface;
@@ -22,11 +23,21 @@ class SoftLimitThresholdIsDueChecker implements IsDueCheckerInterface
 
     public function __construct(
         private readonly ScheduledCommandRepositoryInterface $scheduledCommandRepository,
+        private readonly ?DateTimeProviderInterface $dateTimeProvider = null,
         /**
          * Threshold in minutes
          */
         private readonly int $threshold = 5,
     ) {
+        if (null === $dateTimeProvider) {
+            trigger_deprecation(
+                'synolia/sylius-scheduler-command-plugin',
+                '3.9',
+                'Not passing a service that implements "%s" as a 1st argument of "%s" constructor is deprecated and will be prohibited in 4.0.',
+                DateTimeProviderInterface::class,
+                self::class,
+            );
+        }
     }
 
     /**
@@ -35,7 +46,7 @@ class SoftLimitThresholdIsDueChecker implements IsDueCheckerInterface
     public function isDue(CommandInterface $command, ?\DateTimeInterface $dateTime = null): bool
     {
         if (!$dateTime instanceof \DateTimeInterface) {
-            $dateTime = new \DateTime();
+            $dateTime = $this->dateTimeProvider?->now() ?? new \DateTime();
         }
 
         $cron = new CronExpression($command->getCronExpression());

--- a/src/Checker/SoftLimitThresholdIsDueChecker.php
+++ b/src/Checker/SoftLimitThresholdIsDueChecker.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Synolia\SyliusSchedulerCommandPlugin\Checker;
 
 use Cron\CronExpression;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 use Sylius\Calendar\Provider\DateTimeProviderInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 use Synolia\SyliusSchedulerCommandPlugin\Components\Exceptions\Checker\IsNotDueException;
 use Synolia\SyliusSchedulerCommandPlugin\Entity\CommandInterface;
 use Synolia\SyliusSchedulerCommandPlugin\Repository\ScheduledCommandRepositoryInterface;
@@ -29,7 +29,7 @@ class SoftLimitThresholdIsDueChecker implements IsDueCheckerInterface
          */
         private readonly int $threshold = 5,
     ) {
-        if (null === $dateTimeProvider) {
+        if (!$dateTimeProvider instanceof DateTimeProviderInterface) {
             trigger_deprecation(
                 'synolia/sylius-scheduler-command-plugin',
                 '3.9',

--- a/src/Provider/CalendarWithTimezone.php
+++ b/src/Provider/CalendarWithTimezone.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of SyliusSchedulerCommandPlugin website.
+ *
+ * (c) SyliusSchedulerCommandPlugin <sylius+syliusschedulercommandplugin@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Synolia\SyliusSchedulerCommandPlugin\Provider;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Exception;
+use Sylius\Calendar\Provider\DateTimeProviderInterface;
+
+final class CalendarWithTimezone implements DateTimeProviderInterface
+{
+    public function __construct(
+        private ?string $timezone = null,
+    ) {
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function now(): \DateTimeInterface
+    {
+        $timezone = $this->timezone ?? date_default_timezone_get();
+
+        return new DateTimeImmutable(timezone: new DateTimeZone($timezone));
+    }
+}

--- a/src/Provider/CalendarWithTimezone.php
+++ b/src/Provider/CalendarWithTimezone.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of SyliusSchedulerCommandPlugin website.
- *
- * (c) SyliusSchedulerCommandPlugin <sylius+syliusschedulercommandplugin@monsieurbiz.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 declare(strict_types=1);
 
 namespace Synolia\SyliusSchedulerCommandPlugin\Provider;
@@ -17,10 +8,14 @@ use DateTimeImmutable;
 use DateTimeZone;
 use Exception;
 use Sylius\Calendar\Provider\DateTimeProviderInterface;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
+#[AsAlias(DateTimeProviderInterface::class)]
 final class CalendarWithTimezone implements DateTimeProviderInterface
 {
     public function __construct(
+        #[Autowire(param: 'env(SYNOLIA_SCHEDULER_PLUGIN_TIMEZONE)')]
         private ?string $timezone = null,
     ) {
     }

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -3,6 +3,7 @@ parameters:
     env(SYNOLIA_SCHEDULER_PLUGIN_KEEP_ALIVE): true
     env(SYNOLIA_SCHEDULER_PLUGIN_LOGS_DIR): '%kernel.logs_dir%'
     env(SYNOLIA_SCHEDULER_PLUGIN_TIMEFORMAT_24H): false
+    env(SYNOLIA_SCHEDULER_PLUGIN_TIMEZONE): null
 
 services:
     _defaults:

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -3,7 +3,7 @@ parameters:
     env(SYNOLIA_SCHEDULER_PLUGIN_KEEP_ALIVE): true
     env(SYNOLIA_SCHEDULER_PLUGIN_LOGS_DIR): '%kernel.logs_dir%'
     env(SYNOLIA_SCHEDULER_PLUGIN_TIMEFORMAT_24H): false
-    env(SYNOLIA_SCHEDULER_PLUGIN_TIMEZONE): null
+    env(SYNOLIA_SCHEDULER_PLUGIN_TIMEZONE): ~
 
 services:
     _defaults:

--- a/tests/PHPUnit/Checker/EveryMinuteIsDueCheckerTest.php
+++ b/tests/PHPUnit/Checker/EveryMinuteIsDueCheckerTest.php
@@ -10,6 +10,14 @@ use Tests\Synolia\SyliusSchedulerCommandPlugin\PHPUnit\AbstractIsDueTestCase;
 
 class EveryMinuteIsDueCheckerTest extends AbstractIsDueTestCase
 {
+    private EveryMinuteIsDueChecker $everyMinuteIsDueChecker;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->everyMinuteIsDueChecker = static::getContainer()->get(EveryMinuteIsDueChecker::class);
+    }
+
     /**
      * @dataProvider isDueUsingCronExpressionDataProvider
      */
@@ -18,13 +26,12 @@ class EveryMinuteIsDueCheckerTest extends AbstractIsDueTestCase
         \DateTimeInterface $currentDateTime,
         bool $expectedResult,
     ): void {
-        $checker = new EveryMinuteIsDueChecker();
         $command = $this->setupCommand($cronExpression);
 
         if ($expectedResult === false) {
             $this->expectException(IsNotDueException::class);
         }
 
-        $this->assertEquals($expectedResult, $checker->isDue($command, $currentDateTime));
+        $this->assertEquals($expectedResult, $this->everyMinuteIsDueChecker->isDue($command, $currentDateTime));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Fixed issue   | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

<!--
- Replace this comment by a description of what your PR is solving.
-->

As explained in the README, this PR lets you define a different timezone for scheduled tasks.

For example, I'm using the UTC timezone in my PHP config, but I want my scheduled tasks to be launched on the Paris timezone.
I change the value of the env variable in a `.env`:

```
SYNOLIA_SCHEDULER_PLUGIN_TIMEZONE=Europe/Paris
```