### PR TITLE
Display pending commands

### DIFF
--- a/src/Resources/config/grids.yaml
+++ b/src/Resources/config/grids.yaml
@@ -91,7 +91,7 @@ sylius_grid:
                         template: '@SynoliaSyliusSchedulerCommandPlugin/Grid/Column/scheduled_command_state.html.twig'
                 executedAt:
                     type: scheduled_command_executed_at
-                    sortable: ~
+                    sortable: createdAt
                     label: synolia.ui.scheduled_command.last_execution
                     options:
                         date_format: !php/const \IntlDateFormatter::SHORT


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Fixed issue   | 
| License       | MIT

Pending commands are currently on the last page of the command history, because pending commands have no start datetime.
The purpose of this PR is to bring them up first, in the following order: 
* Pending commands
* Commands in progress
* Finished commands
