### PR TITLE
[Feat] Execute only one scheduled command in a run

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ Execute scheduled commands.
 
 **Run all scheduled commands :** php bin/console synolia:scheduler-run
 
-**Run one scheduled command :** php bin/console synolia:scheduler-run --id=5
+**Run one scheduled command :** php bin/console synolia:scheduler-run --only-one
+
+**Run a specific scheduled command :** php bin/console synolia:scheduler-run --id=5
 
 ### synolia:scheduler:purge-history
 

--- a/tests/PHPUnit/Command/SynoliaSchedulerRunCommandTest.php
+++ b/tests/PHPUnit/Command/SynoliaSchedulerRunCommandTest.php
@@ -78,7 +78,7 @@ final class SynoliaSchedulerRunCommandTest extends KernelTestCase
         $command = $application->find(self::$commandName);
         $commandTester = new CommandTester($command);
         $commandTester->execute([]);
-        self::assertStringContainsString('Execute Command "about" - last execution : never', $commandTester->getDisplay());
+        self::assertStringContainsString('Execute Command "about"', $commandTester->getDisplay());
         self::assertStringNotContainsString('Nothing to do', $commandTester->getDisplay());
     }
 
@@ -95,7 +95,7 @@ final class SynoliaSchedulerRunCommandTest extends KernelTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute([]);
         self::assertStringContainsString('Immediately execution asked for : about', $commandTester->getDisplay());
-        self::assertStringContainsString('Execute Command "about" - last execution : never', $commandTester->getDisplay());
+        self::assertStringContainsString('Execute Command "about"', $commandTester->getDisplay());
         self::assertStringNotContainsString('Nothing to do', $commandTester->getDisplay());
         self::assertFalse($scheduledCommand->isExecuteImmediately());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Fixed issue   | 
| License       | MIT

The purpose of this PR is to execute a single scheduled command when running the scheduler.
This can be useful for long runs or when using several Schedulers in parallel.