### PR TITLE
[Feat] Better command interruption management

### DIFF
--- a/src/EventSubscriber/ConsoleSubscriber.php
+++ b/src/EventSubscriber/ConsoleSubscriber.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Synolia\SyliusSchedulerCommandPlugin\EventSubscriber;
+
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleSignalEvent;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Synolia\SyliusSchedulerCommandPlugin\Entity\ScheduledCommand;
+use Synolia\SyliusSchedulerCommandPlugin\Enum\ScheduledCommandStateEnum;
+use Synolia\SyliusSchedulerCommandPlugin\Repository\ScheduledCommandRepository;
+
+final class ConsoleSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly ScheduledCommandRepository $scheduledCommandRepository,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ConsoleEvents::TERMINATE => 'onConsoleTerminate',
+            ConsoleEvents::SIGNAL => 'onConsoleSignal',
+        ];
+    }
+
+    public function onConsoleTerminate(ConsoleTerminateEvent $event): void
+    {
+        $this->updateCommand($event);
+    }
+
+    public function onConsoleSignal(ConsoleSignalEvent $event): void
+    {
+        $this->updateCommand($event);
+    }
+
+    private function updateCommand(ConsoleSignalEvent|ConsoleTerminateEvent $event): void
+    {
+        try {
+            $commandCode = $event->getCommand()?->getName() ?? 'no_command';
+            /** @var ScheduledCommand|null $schedulerCommand */
+            $schedulerCommand = $this->scheduledCommandRepository->findOneBy(['command' => $commandCode], ['id' => 'DESC']);
+        } catch (\Throwable) {
+            return;
+        }
+
+        if (null === $schedulerCommand) {
+            return;
+        }
+
+        if ($schedulerCommand->getState() !== ScheduledCommandStateEnum::IN_PROGRESS) {
+            return;
+        }
+
+        $exitCode = $event->getExitCode();
+        if (false === $exitCode) {
+            $exitCode = -1;
+        }
+
+        $schedulerCommand->setCommandEndTime(new \DateTime());
+        $schedulerCommand->setState(ScheduledCommandStateEnum::TERMINATION);
+        $schedulerCommand->setLastReturnCode($exitCode);
+        $this->scheduledCommandRepository->add($schedulerCommand);
+    }
+}

--- a/src/EventSubscriber/ConsoleSubscriber.php
+++ b/src/EventSubscriber/ConsoleSubscriber.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Synolia\SyliusSchedulerCommandPlugin\EventSubscriber;
 
+use Doctrine\DBAL\Exception;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleSignalEvent;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
@@ -43,7 +44,7 @@ final class ConsoleSubscriber implements EventSubscriberInterface
             $commandCode = $event->getCommand()?->getName() ?? 'no_command';
             /** @var ScheduledCommand|null $schedulerCommand */
             $schedulerCommand = $this->scheduledCommandRepository->findOneBy(['command' => $commandCode], ['id' => 'DESC']);
-        } catch (\Throwable) {
+        } catch (Exception) {
             return;
         }
 

--- a/src/Resources/views/Grid/Column/scheduled_command_state.html.twig
+++ b/src/Resources/views/Grid/Column/scheduled_command_state.html.twig
@@ -23,7 +23,7 @@
     </span>
 {% endif %}
 {% if schedulerCommand.state == 'termination' %}
-    <span class="ui red label">
+    <span class="ui orange label">
         <i class="bell icon"></i>
         {{ ('synolia.ui.statuses.' ~ schedulerCommand.state)|trans }}
     </span>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Fixed issue   | 
| License       | MIT

Currently, when a Command is interrupted (killed by the system, for example), the Command remains “in progress”.
This PR updates the command to mark it as “Cancelled”.

![image](https://github.com/user-attachments/assets/1b79b27f-458a-44ed-bbe6-bd2cde6161c6)
NB : "Annulée" in French means "Cancelled" in English 

